### PR TITLE
Remove warnings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,7 @@
+L2 cache library change log
+===========================
+
+1.0.0
+-----
+
+  * Initial version

--- a/lib_l2_cache/src/l2_cache_direct_map.c
+++ b/lib_l2_cache/src/l2_cache_direct_map.c
@@ -73,7 +73,7 @@ void l2_cache_setup_direct_map(
     l2_cache_config.line_size_bytes = line_size_bytes;
     l2_cache_config.line_size = line_bits;
 
-    if(L2_CACHE_DEBUG_ON) {
+    #if L2_CACHE_DEBUG_ON
         // First two address bits for SwMem are always 01  (0x40000000 - 0x7FFFFFFF), so
         // they needn't be included in the tag.
 
@@ -91,7 +91,7 @@ void l2_cache_setup_direct_map(
         DEBUG_PRINT("Offset Mask: 0x%08X\n", (unsigned) l2_cache_config.offset_mask);
         DEBUG_PRINT("Cache Size: %u B\n", line_count * line_size_bytes);
         DEBUG_PRINT("Tag Table Size: %u B\n", line_count * sizeof(int));
-    }
+    #endif // L2_CACHE_DEBUG_ON
 
     for(int k = 0; k < line_count; k++) {
         l2_cache_config.tag_table[k] = DIRTY_TAG_VALUE;

--- a/lib_l2_cache/src/l2_cache_two_way.c
+++ b/lib_l2_cache/src/l2_cache_two_way.c
@@ -140,8 +140,6 @@ void l2_cache_setup_two_way(
 
     // bytes
     const unsigned entry_size = N_WAY * (line_size_bytes + sizeof(tag_t) + sizeof(uint32_t));
-    // bytes
-    const unsigned cache_size = entry_size * line_count;
 
     DEBUG_ASSERT( line_size_bytes >= 32 ); // minimum line size is 32 bytes
     DEBUG_ASSERT( (1<<line_bits) == line_size_bytes); // line_size_bytes is a power of 2
@@ -157,7 +155,10 @@ void l2_cache_setup_two_way(
     cache_config.line_size.bits = line_bits;
     cache_config.entry_bytes = entry_size;
 
-    if(L2_CACHE_DEBUG_ON) {
+    #if L2_CACHE_DEBUG_ON
+        // bytes
+        const unsigned cache_size = entry_size * line_count;
+
         const unsigned buffer_end = ((unsigned)cache_buffer) + cache_size - 1;
 
         DEBUG_PRINT("%s","Cache Type: 2-Way Set Associative (read-only)\n");
@@ -169,7 +170,7 @@ void l2_cache_setup_two_way(
         DEBUG_PRINT("Read Func:   0x%08X\n", (unsigned) read_func);
         DEBUG_PRINT("Cache Size: %u B\n", line_count * 2*line_size_bytes);
         DEBUG_PRINT("Cache Entry Size: %u B\n", cache_config.entry_bytes);
-    }
+    #endif // L2_CACHE_DEBUG_ON
 
     for(int k = 0; k < line_count; k++){
         for(int a = 0; a < N_WAY; a++) {


### PR DESCRIPTION
The following warnings have been seen on XVF3800:
```

[2023-10-24T03:31:18.920Z] C:/jenkins/workspace/odules_modules_fwk_xvf-97ad00a_2/sources/modules/fwk_xvf/modules/core/modules/l2_cache/lib_l2_cache/lib_l2_cache/src/l2_cache_direct_map.c:80:24: warning: unused variable 'data_table_end' [-Wunused-variable]
[2023-10-24T03:31:18.920Z]         const unsigned data_table_end = ((unsigned)data_table) + line_count*line_size_bytes - 1;
[2023-10-24T03:31:18.920Z]                        ^
[2023-10-24T03:31:19.180Z] C:/jenkins/workspace/odules_modules_fwk_xvf-97ad00a_2/sources/modules/fwk_xvf/modules/core/modules/l2_cache/lib_l2_cache/lib_l2_cache/src/l2_cache_direct_map.c:81:24: warning: unused variable 'tag_table_end' [-Wunused-variable]

[2023-10-24T03:31:19.180Z]         const unsigned tag_table_end = ((unsigned)tag_table) + line_count*sizeof(uint16_t) - 1;

[2023-10-24T03:31:19.180Z]                        ^

[2023-10-24T03:31:19.180Z] 2 warnings generated.
```

Part of https://github.com/xmos/sw_xvf3800/issues/1206

Closes https://xmosjira.atlassian.net/browse/AP-208